### PR TITLE
Remove unused variables and replace any types with proper typings

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    turbo: false,
-  },
-};
+const nextConfig = {};
 
 module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@fortawesome/react-fontawesome": "^3.0.1",
         "@heroicons/react": "^2.2.0",
         "@tailwindcss/line-clamp": "^0.4.4",
+        "github-slugger": "^2.0.0",
         "gray-matter": "^4.0.3",
         "next": "15.3.5",
         "phosphor-react": "^1.4.1",
@@ -3821,6 +3822,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@fortawesome/react-fontawesome": "^3.0.1",
     "@heroicons/react": "^2.2.0",
     "@tailwindcss/line-clamp": "^0.4.4",
+    "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.3",
     "next": "15.3.5",
     "phosphor-react": "^1.4.1",

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import Link from "next/link";
-import SearchInput from "./SearchInput";
 import { useState, useEffect, useRef } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCircleLeft } from "@fortawesome/free-solid-svg-icons";
 
-export default function Layout({ children }: { children: React.ReactNode }) {
-    const [query, setQuery] = useState("");
+type LayoutProps = {
+    children: React.ReactNode;
+};
+
+export default function Layout({ children }: LayoutProps) {
     const [showHeader, setShowHeader] = useState(true);
     const lastScrollY = useRef(0);
 
@@ -42,17 +44,19 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                             bg-gradient-to-r from-pink-500 via-purple-500 to-blue-500
                             text-white shadow hover:opacity-90 transition"
                             title="Back to Home"
+                            aria-label="Back to Home"
                         >
                             <FontAwesomeIcon icon={faCircleLeft} className="w-5 h-5" />
                         </Link>
                     </div>
 
                     {/* 中央：ロゴ */}
-                    <div className="absolute left-1/2 transform -translate-x-1/2">
+                    <div className="absolute left-1/2 -translate-x-1/2">
                         <Link
                             href="/"
                             className="text-xl font-bold text-transparent bg-clip-text
                             bg-gradient-to-r from-pink-600 via-purple-600 to-blue-600"
+                            aria-label="Hamayan.dev home"
                         >
                             Hamayan.dev
                         </Link>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -8,25 +8,34 @@ export default function PostCard({
 }: {
     slug: string;
     title: string;
-    date: string;
+    date?: string;
     tags?: string[];
 }) {
     return (
         <Link href={`/blog/${slug}`} className="block group h-full">
-            <article className="relative flex flex-col h-full justify-between
+            <article
+                className="relative flex flex-col h-full justify-between
                 p-4 sm:p-6 rounded-2xl border border-gray-100
                 bg-white shadow-md hover:shadow-xl hover:border-purple-300
-                transition-all duration-300 ease-in-out">
-
-                <div className="absolute top-0 left-0 w-full h-1
+                transition-all duration-300 ease-in-out"
+            >
+                <div
+                    className="absolute top-0 left-0 w-full h-1
                     bg-gradient-to-r from-purple-400 via-purple-500 to-purple-600
-                    rounded-t-2xl" />
+                    rounded-t-2xl"
+                />
 
-                <h2 className="text-lg sm:text-xl font-extrabold text-gray-800 mb-2
-                    group-hover:text-purple-700 transition-colors line-clamp-2">
+                <h2
+                    className="text-lg sm:text-xl font-extrabold text-gray-800 mb-2
+                    group-hover:text-purple-700 transition-colors line-clamp-2"
+                >
                     {title}
                 </h2>
-                <p className="text-xs sm:text-sm text-gray-500 mb-4">{date}</p>
+
+                {/* date があるときだけ表示 */}
+                {date && (
+                    <p className="text-xs sm:text-sm text-gray-500 mb-4">{date}</p>
+                )}
 
                 {tags.length > 0 && (
                     <div className="flex flex-wrap gap-2 mt-auto">

--- a/src/components/SearchablePosts.tsx
+++ b/src/components/SearchablePosts.tsx
@@ -1,28 +1,48 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import SearchInput from "./SearchInput";
 import PostCard from "./PostCard";
 
-export default function SearchablePosts({ posts }: { posts: any[] }) {
-    const [query, setQuery] = useState("");
+/** 記事メタ情報の型 */
+export type PostMeta = {
+    title: string;
+    date?: string;
+    tags?: string[];
+};
 
-    const filteredPosts = posts.filter(
-        (post) =>
-            post.meta.title.toLowerCase().includes(query.toLowerCase()) ||
-            post.meta.tags.some((tag: string) =>
-                tag.toLowerCase().includes(query.toLowerCase())
-            )
-    );
+/** 記事の型 */
+export type Post = {
+    slug: string;
+    meta: PostMeta;
+};
+
+type Props = {
+    posts: Post[];
+};
+
+export default function SearchablePosts({ posts }: Props) {
+    const [query, setQuery] = useState<string>("");
+
+    const filteredPosts = useMemo(() => {
+        const q = query.toLowerCase().trim();
+        return posts.filter((post) => {
+            const titleHit = post.meta.title.toLowerCase().includes(q);
+            const tags = post.meta.tags ?? [];
+            const tagHit = tags.some((tag) => tag.toLowerCase().includes(q));
+            return titleHit || tagHit;
+        });
+    }, [posts, query]);
 
     return (
-        <main className="max-w-3xl sm:max-w-5xl lg:max-w-7xl mx-auto
+        <main
+            className="max-w-3xl sm:max-w-5xl lg:max-w-7xl mx-auto
             px-4 sm:px-6 lg:px-8 pt-10 md:pt-12 pb-16 md:pb-20
-            min-h-[60vh] flex flex-col">
-
+            min-h-[60vh] flex flex-col"
+        >
             {/* 🔍 検索フォーム */}
             <div className="mb-8 sm:mb-10">
-                <SearchInput onSearch={(q) => setQuery(q)} />
+                <SearchInput onSearch={(v: string) => setQuery(v)} />
             </div>
 
             {/* セクションヘッダー */}
@@ -33,8 +53,10 @@ export default function SearchablePosts({ posts }: { posts: any[] }) {
                 <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
                     開発の学びと知見を記録しています。
                 </p>
-                <div className="mt-4 w-12 sm:w-16 h-1 mx-auto
-                    bg-gradient-to-r from-pink-500 via-purple-500 to-blue-500 rounded-full"></div>
+                <div
+                    className="mt-4 w-12 sm:w-16 h-1 mx-auto
+                    bg-gradient-to-r from-pink-500 via-purple-500 to-blue-500 rounded-full"
+                />
             </div>
 
             {/* カードリスト */}
@@ -49,17 +71,19 @@ export default function SearchablePosts({ posts }: { posts: any[] }) {
                                 slug={post.slug}
                                 title={post.meta.title}
                                 date={post.meta.date}
-                                tags={post.meta.tags}
+                                tags={post.meta.tags ?? []}
                             />
                         </div>
                     ))
                 ) : (
                     <div className="flex items-center justify-center col-span-full py-12 sm:py-20">
-                        <div className="text-center max-w-md
+                        <div
+                            className="text-center max-w-md
                             bg-gradient-to-br from-gray-50 to-white
                             dark:from-gray-800 dark:to-gray-900
                             border border-gray-200 dark:border-gray-700
-                            rounded-lg p-6 sm:p-10 shadow-sm">
+                            rounded-lg p-6 sm:p-10 shadow-sm"
+                        >
                             <h3 className="text-base sm:text-lg font-semibold text-gray-700 dark:text-gray-200">
                                 記事が見つかりませんでした
                             </h3>

--- a/src/lib/remark-toc.ts
+++ b/src/lib/remark-toc.ts
@@ -1,35 +1,68 @@
-// lib/remark-toc.ts
+// src/lib/remark-toc.ts
 import { visit } from "unist-util-visit";
+import { toString } from "mdast-util-to-string";
+import GithubSlugger from "github-slugger";
+import type { Root, Heading } from "mdast";
+import type { Properties } from "hast";
+import type { Plugin } from "unified";
 
-export function remarkExtractToc(toc: any[]) {
-    const slugCount: Record<string, number> = {};
+export type TocItem = { depth: number; text: string; id: string };
 
-    return () => (tree: any) => {
-        visit(tree, "heading", (node: any) => {
-            if (node.depth <= 3) {
-                const text = node.children
-                    .filter((c: any) => c.type === "text" || c.type === "inlineCode")
-                    .map((c: any) => c.value)
-                    .join(" ");
+type VFileLike = { data?: Record<string, unknown> };
+type HeadingData = { hProperties?: Properties } & Record<string, unknown>;
 
-                let slug = text
-                    .toLowerCase()
-                    .replace(/\s+/g, "-")
-                    .replace(/[^\w-]/g, "");
+/** プラグインのオプション（target に TOC を格納したい配列を渡せる） */
+export type RemarkTocOptions = {
+    target?: TocItem[];
+};
 
-                if (slugCount[slug]) {
-                    slugCount[slug] += 1;
-                    slug = `${slug}-${slugCount[slug]}`;
-                } else {
-                    slugCount[slug] = 1;
-                }
+/** 安全ガード */
+function isRoot(x: unknown): x is Root {
+    return !!x && typeof x === "object" && (x as { type?: unknown }).type === "root";
+}
+function isHeadingNode(n: unknown): n is Heading {
+    return !!n && typeof n === "object" && (n as { type?: unknown }).type === "heading";
+}
 
-                if (!node.data) node.data = {};
-                if (!node.data.hProperties) node.data.hProperties = {};
-                node.data.hProperties.id = slug;
+/**
+ * remark プラグイン：見出し(H1〜H3)から TOC を抽出し、
+ * - options.target があればそこへ格納
+ * - なければ file.data.toc に格納
+ * 各見出しに id を付与（rehype で hProperties が反映される）
+ */
+export const remarkExtractToc: Plugin<[RemarkTocOptions?], Root> = (options) => {
+    return (tree: Root, file?: VFileLike) => {
+        if (!isRoot(tree) || !Array.isArray((tree as unknown as { children?: unknown[] }).children)) {
+            if (file) {
+                file.data ??= {};
+                (file.data as Record<string, unknown>).toc = [];
+            }
+            return;
+        }
 
-                toc.push({ depth: node.depth, text, id: slug });
+        const slugger = new GithubSlugger();
+        const toc: TocItem[] = [];
+
+        visit(tree, "heading", (node) => {
+            if (!isHeadingNode(node)) return;
+            if (node.depth >= 1 && node.depth <= 3) {
+                const text = toString(node);
+                const id = slugger.slug(text);
+
+                const data = (node.data ??= {}) as HeadingData;
+                data.hProperties ??= {};
+                data.hProperties.id = id;
+
+                toc.push({ depth: node.depth, text, id });
             }
         });
+
+        if (options?.target) {
+            // 渡された配列を差し替え（参照を保ちつつ中身だけ入れ替える）
+            options.target.splice(0, options.target.length, ...toc);
+        } else if (file) {
+            file.data ??= {};
+            (file.data as Record<string, unknown>).toc = toc;
+        }
     };
-}
+};


### PR DESCRIPTION

---

## 目的・背景

- **目次の品質向上**  
  記事が増えると目次の整合性・一意性・可読性が重要になる。従来方式では重複IDや整合性の問題があったため、GitHub互換のslug生成と型安全な実装に刷新。
- **アクセシビリティ・ユーザビリティの改善**  
  aria属性追加やUIの細部調整で、アクセシブルかつ一貫したUXを提供。
- **型安全性・保守性向上**  
  TypeScript型導入で今後の機能追加や不具合修正を容易に。
- **パフォーマンス・信頼性**  
  検索メモ化や存在チェックで余計な再描画やエラーを防止し、快適な閲覧体験を実現。


---

## 実装内容

### 1. 目次(TOC)生成処理の大幅リファクタ・強化

- **`src/lib/remark-toc.ts`** を全面的にリファクタし、型定義やプラグインオプション、slug生成方法を改善。
  - **`github-slugger`**パッケージを導入し、見出しID（アンカー）生成をGitHub互換の確実なものに変更。
  - H1〜H3の見出しを自動抽出し、TOC配列に格納。各見出しノードにidも付与。
  - 型安全な実装に刷新し、プラグインオプションでTOC格納先（target）を外部から指定できるようにした。
- **`src/app/blog/[slug]/page.tsx`** でTOC生成ロジックを新仕様に合わせて変更。
  - TOC抽出のためのremarkプラグイン呼び出し方法も新APIに対応。
  - TOCが存在する場合のみ目次を表示するように調整。

### 2. 検索・記事カードUI・型定義の強化

- **`src/components/SearchablePosts.tsx`**, **`src/components/PostCard.tsx`**
  - 記事メタ情報・記事型をTypeScript型で厳密に管理するように修正。
  - タイトル・タグによる検索処理を`useMemo`によるメモ化で効率化。
  - 記事の日付・タグが存在する場合のみUI表示。`date`をオプショナル型にして柔軟性UP。
- **`src/components/Layout.tsx`**
  - アクセシビリティ向上のため`aria-label`など属性追加。
  - 中央ロゴのレイアウトclass見直し（`transform`除去）。

### 3. パッケージ追加・設定調整

- **`github-slugger`の追加**（`package.json`）。
  - 見出しID生成のため。
- **不要なNext.js実験機能設定の削除**（`next.config.ts`）。

---

## 実装方法

- 目次生成を独自ロジックから、OSS標準のslug生成を用いた堅牢な方式に切り替え。
- TypeScriptの型定義を明確にし、propsやデータ構造の意図しないバグを防止。
- UI表示条件を「存在する場合のみ」にすることで、空データ時の見た目崩れを防止。
- Reactのパフォーマンス最適化（`useMemo`）を検索部分に適用。

---

## まとめ

**目次生成・記事検索UIおよび型定義を改善し、拡張性・信頼性・アクセシビリティを高める大規模なリファクタ・機能向上**が主な目的です。  
これにより、記事が増えても見やすく、今後の発展にも耐えうる堅牢なブログ基盤になっています。